### PR TITLE
Add Renesas USB-MIDI dependency and architecture keywords

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,5 @@ sentence=Arduino library for sending MIDI messages using Adafruit_TinyUSB.
 paragraph=This library simplifies sending MIDI messages via USB using the Adafruit_TinyUSB library.
 category=Communication
 url=https://github.com/silveirago/Adafruit_TinyUSB_MIDI
-architectures=*
+architectures=*,renesas_uno,renesas_nano
+depends=Arduino_USB_MIDI


### PR DESCRIPTION
## Summary
- include Arduino_USB_MIDI as a library dependency
- list renesas_uno and renesas_nano in architectures for UNO R4 and Nano R4 boards

## Testing
- `arduino-cli version` *(fails: command not found)*
- `pip install arduino-cli` *(fails: Tunnel connection failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_689a459634e4832a9dce976eef8491de