### PR TITLE
Add Renesas USBMIDI support

### DIFF
--- a/Adafruit_TinyUSB_MIDI.cpp
+++ b/Adafruit_TinyUSB_MIDI.cpp
@@ -1,22 +1,89 @@
+// Adafruit TinyUSB MIDI implementation
 #include "Adafruit_TinyUSB_MIDI.h"
 
 // Initialize the global MIDI instance
 //Adafruit_TinyUSB_MIDI MIDI;
 
-// Adafruit_TinyUSB_MIDI constructor
+#ifdef ADAFRUIT_TINYUSB_MIDI_RENESAS
+
+Adafruit_TinyUSB_MIDI::Adafruit_TinyUSB_MIDI(uint8_t n_cables) : _midi() {}
+
+bool Adafruit_TinyUSB_MIDI::begin() {
+    _midi.begin();
+    return true;
+}
+
+TinyUSBMIDI_Device& Adafruit_TinyUSB_MIDI::getMidiInstance() {
+    return _midi;
+}
+
+void Adafruit_TinyUSB_MIDI::sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) {
+    _midi.sendNoteOn(note, velocity, channel);
+}
+
+void Adafruit_TinyUSB_MIDI::sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) {
+    _midi.sendNoteOff(note, velocity, channel);
+}
+
+void Adafruit_TinyUSB_MIDI::sendControlChange(uint8_t controlNumber, uint8_t controlValue, uint8_t channel) {
+    _midi.sendControlChange(controlNumber, controlValue, channel);
+}
+
+void Adafruit_TinyUSB_MIDI::sendProgramChange(uint8_t programNumber, uint8_t channel) {
+    _midi.sendProgramChange(programNumber, channel);
+}
+
+void Adafruit_TinyUSB_MIDI::sendPitchBend(int16_t bendValue, uint8_t channel) {
+    _midi.sendPitchBend(bendValue, channel);
+}
+
+void Adafruit_TinyUSB_MIDI::sendSysEx(size_t length, uint8_t *data) {
+    _midi.sendSysEx(data, length);
+}
+
+void Adafruit_TinyUSB_MIDI::sendChannelPressure(uint8_t pressure, uint8_t channel) {
+    _midi.sendChannelPressure(pressure, channel);
+}
+
+void Adafruit_TinyUSB_MIDI::sendAfterTouch(uint8_t note, uint8_t pressure, uint8_t channel) {
+    _midi.sendAfterTouch(note, pressure, channel);
+}
+
+void Adafruit_TinyUSB_MIDI::sendPolyPressure(uint8_t note, uint8_t pressure, uint8_t channel) {
+    _midi.sendPolyPressure(note, pressure, channel);
+}
+
+void Adafruit_TinyUSB_MIDI::sendTimeCodeQuarterFrame(uint8_t typeNibble, uint8_t valuesNibble) {
+    _midi.sendTimeCodeQuarterFrame(typeNibble, valuesNibble);
+}
+
+void Adafruit_TinyUSB_MIDI::sendSongPosition(uint16_t beats) {
+    _midi.sendSongPosition(beats);
+}
+
+void Adafruit_TinyUSB_MIDI::sendSongSelect(uint8_t songNumber) {
+    _midi.sendSongSelect(songNumber);
+}
+
+void Adafruit_TinyUSB_MIDI::sendTuneRequest() {
+    _midi.sendTuneRequest();
+}
+
+void Adafruit_TinyUSB_MIDI::sendRealTime(uint8_t realTimeType) {
+    _midi.sendRealTime(realTimeType);
+}
+
+#else
+
 Adafruit_TinyUSB_MIDI::Adafruit_TinyUSB_MIDI(uint8_t n_cables) : _midi(n_cables) {}
 
-// Begin MIDI interface
 bool Adafruit_TinyUSB_MIDI::begin() {
     return _midi.begin();
 }
 
-// Expose the MIDI instance
-Adafruit_USBD_MIDI& Adafruit_TinyUSB_MIDI::getMidiInstance() {
+TinyUSBMIDI_Device& Adafruit_TinyUSB_MIDI::getMidiInstance() {
     return _midi;
 }
-
-// Implementing the sending functions
 
 void Adafruit_TinyUSB_MIDI::sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) {
     uint8_t packet[4] = {static_cast<uint8_t>(0x09), static_cast<uint8_t>(0x90 | (channel & 0x0F)), note, velocity};
@@ -28,19 +95,16 @@ void Adafruit_TinyUSB_MIDI::sendNoteOff(uint8_t note, uint8_t velocity, uint8_t 
     _midi.writePacket(packet);
 }
 
-// Control Change
 void Adafruit_TinyUSB_MIDI::sendControlChange(uint8_t controlNumber, uint8_t controlValue, uint8_t channel) {
     uint8_t packet[4] = {static_cast<uint8_t>(0x0B), static_cast<uint8_t>(0xB0 | (channel & 0x0F)), controlNumber, controlValue};
     _midi.writePacket(packet);
 }
 
-// Program Change
 void Adafruit_TinyUSB_MIDI::sendProgramChange(uint8_t programNumber, uint8_t channel) {
     uint8_t packet[4] = {static_cast<uint8_t>(0x0C), static_cast<uint8_t>(0xC0 | (channel & 0x0F)), programNumber, 0};
     _midi.writePacket(packet);
 }
 
-// Pitch Bend
 void Adafruit_TinyUSB_MIDI::sendPitchBend(int16_t bendValue, uint8_t channel) {
     uint8_t lsb = bendValue & 0x7F;
     uint8_t msb = (bendValue >> 7) & 0x7F;
@@ -48,61 +112,55 @@ void Adafruit_TinyUSB_MIDI::sendPitchBend(int16_t bendValue, uint8_t channel) {
     _midi.writePacket(packet);
 }
 
-// SysEx
 void Adafruit_TinyUSB_MIDI::sendSysEx(size_t length, uint8_t *data) {
     _midi.write(data, length);
 }
 
-// Channel Pressure
 void Adafruit_TinyUSB_MIDI::sendChannelPressure(uint8_t pressure, uint8_t channel) {
     uint8_t packet[4] = {static_cast<uint8_t>(0x0D), static_cast<uint8_t>(0xD0 | (channel & 0x0F)), pressure, 0};
     _midi.writePacket(packet);
 }
 
-// Aftertouch
 void Adafruit_TinyUSB_MIDI::sendAfterTouch(uint8_t note, uint8_t pressure, uint8_t channel) {
     uint8_t packet[4] = {static_cast<uint8_t>(0x0A), static_cast<uint8_t>(0xA0 | (channel & 0x0F)), note, pressure};
     _midi.writePacket(packet);
 }
 
-// Poly Pressure
 void Adafruit_TinyUSB_MIDI::sendPolyPressure(uint8_t note, uint8_t pressure, uint8_t channel) {
     uint8_t packet[4] = {static_cast<uint8_t>(0x0A), static_cast<uint8_t>(0xA0 | (channel & 0x0F)), note, pressure};
     _midi.writePacket(packet);
 }
 
-// Time Code Quarter Frame
 void Adafruit_TinyUSB_MIDI::sendTimeCodeQuarterFrame(uint8_t typeNibble, uint8_t valuesNibble) {
     uint8_t packet[4] = {static_cast<uint8_t>(0x02), static_cast<uint8_t>(0xF1), static_cast<uint8_t>((typeNibble << 4) | (valuesNibble & 0x0F)), 0};
     _midi.writePacket(packet);
 }
 
-// Song Position
 void Adafruit_TinyUSB_MIDI::sendSongPosition(uint16_t beats) {
     uint8_t packet[4] = {static_cast<uint8_t>(0x03), static_cast<uint8_t>(0xF2), static_cast<uint8_t>(beats & 0x7F), static_cast<uint8_t>((beats >> 7) & 0x7F)};
     _midi.writePacket(packet);
 }
 
-// Song Select
 void Adafruit_TinyUSB_MIDI::sendSongSelect(uint8_t songNumber) {
     uint8_t packet[4] = {static_cast<uint8_t>(0x02), static_cast<uint8_t>(0xF3), songNumber, 0};
     _midi.writePacket(packet);
 }
 
-// Tune Request
 void Adafruit_TinyUSB_MIDI::sendTuneRequest() {
     uint8_t packet[4] = {static_cast<uint8_t>(0x01), static_cast<uint8_t>(0xF6), 0, 0};
     _midi.writePacket(packet);
 }
 
-// Real-Time Messages
 void Adafruit_TinyUSB_MIDI::sendRealTime(uint8_t realTimeType) {
     uint8_t packet[4] = {static_cast<uint8_t>(0x01), realTimeType, 0, 0};
     _midi.writePacket(packet);
 }
 
-// Adafruit_TinyUSB_MIDI_Input constructor
-Adafruit_TinyUSB_MIDI_Input::Adafruit_TinyUSB_MIDI_Input(Adafruit_USBD_MIDI &midiInstance) : _midi(midiInstance) {
+#endif // ADAFRUIT_TINYUSB_MIDI_RENESAS
+
+#ifndef ADAFRUIT_TINYUSB_MIDI_RENESAS
+
+Adafruit_TinyUSB_MIDI_Input::Adafruit_TinyUSB_MIDI_Input(TinyUSBMIDI_Device &midiInstance) : _midi(midiInstance) {
     // Initialize callback pointers to nullptr
     handleNoteOn = nullptr;
     handleNoteOff = nullptr;
@@ -180,11 +238,10 @@ void Adafruit_TinyUSB_MIDI_Input::setHandleRealTime(void (*fptr)(uint8_t realTim
 
 // Function to process incoming MIDI data
 void Adafruit_TinyUSB_MIDI_Input::read() {
-    uint8_t data[4]; // Buffer for incoming MIDI data
-
-    while (_midi.available()) { // Check if there is data available
-        if (_midi.readPacket(data)) { // Read the incoming packet into the data buffer
-            parseMessage(data, 4); // Parse the incoming message
+    uint8_t data[4];
+    while (_midi.available()) {
+        if (_midi.readPacket(data)) {
+            parseMessage(data, 4);
         }
     }
 }
@@ -256,3 +313,5 @@ void Adafruit_TinyUSB_MIDI_Input::parseMessage(uint8_t *data, size_t length) {
             break;
     }
 }
+
+#endif // ADAFRUIT_TINYUSB_MIDI_RENESAS

--- a/Adafruit_TinyUSB_MIDI.h
+++ b/Adafruit_TinyUSB_MIDI.h
@@ -1,14 +1,21 @@
 #ifndef ADAFRUIT_TINYUSB_MIDI_H
 #define ADAFRUIT_TINYUSB_MIDI_H
 
+#if defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_NANO_R4)
+#define ADAFRUIT_TINYUSB_MIDI_RENESAS
+#include <USBMIDI.h>
+using TinyUSBMIDI_Device = USBMIDI;
+#else
 #include <Adafruit_TinyUSB.h>
+using TinyUSBMIDI_Device = Adafruit_USBD_MIDI;
+#endif
 
 // MIDI class definition for sending MIDI messages
 class Adafruit_TinyUSB_MIDI {
 public:
-    Adafruit_TinyUSB_MIDI(uint8_t n_cables = 1);  // Constructor
+    Adafruit_TinyUSB_MIDI(uint8_t n_cables = 1);
 
-    bool begin();  // Initialize MIDI interface
+    bool begin();
 
     void sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel);
     void sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel);
@@ -28,19 +35,20 @@ public:
     void sendTuneRequest();
     void sendRealTime(uint8_t realTimeType);
 
-    Adafruit_USBD_MIDI& getMidiInstance();  // Expose MIDI instance for input handling
+    TinyUSBMIDI_Device& getMidiInstance();
 
 private:
-    Adafruit_USBD_MIDI _midi;
+    TinyUSBMIDI_Device _midi;
 };
 
 extern Adafruit_TinyUSB_MIDI MIDI;  // Global MIDI instance
 
 // MIDI Input class definition for receiving MIDI messages
+#ifndef ADAFRUIT_TINYUSB_MIDI_RENESAS
 class Adafruit_TinyUSB_MIDI_Input {
 public:
     // Constructor
-    Adafruit_TinyUSB_MIDI_Input(Adafruit_USBD_MIDI &midiInstance);
+    Adafruit_TinyUSB_MIDI_Input(TinyUSBMIDI_Device &midiInstance);
 
     // Functions to set callback functions
     void setHandleNoteOn(void (*fptr)(uint8_t channel, uint8_t note, uint8_t velocity));
@@ -63,7 +71,7 @@ public:
 
 private:
     // Reference to MIDI instance
-    Adafruit_USBD_MIDI &_midi;
+    TinyUSBMIDI_Device &_midi;
 
     // Callback function pointers
     void (*handleNoteOn)(uint8_t channel, uint8_t note, uint8_t velocity);
@@ -84,5 +92,6 @@ private:
     // Function to parse incoming MIDI data
     void parseMessage(uint8_t *data, size_t length);
 };
+#endif
 
 #endif // ADAFRUIT_TINYUSB_MIDI_H


### PR DESCRIPTION
## Summary
- conditionally include Renesas USBMIDI for UNO/Nano R4 boards
- add alternate RA4 USB MIDI implementation with begin and send wrappers
- guard TinyUSB-specific input class for non-Renesas boards

## Testing
- `g++ -c -I. Adafruit_TinyUSB_MIDI.cpp` *(fails: Adafruit_TinyUSB.h missing)*
- `g++ -c -I. -DARDUINO_UNOR4_MINIMA Adafruit_TinyUSB_MIDI.cpp` *(fails: USBMIDI.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_689a4596b298832a8410f607403ef577