### PR TITLE
Document RA4 board usage and update MIDI example

### DIFF
--- a/Examples/MIDI_write/MIDI_write.ino
+++ b/Examples/MIDI_write/MIDI_write.ino
@@ -1,6 +1,12 @@
+#if defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_NANO_R4)
+// Renesas RA4 boards provide a built-in USBMIDI interface
+#include <USBMIDI.h>
+USBMIDI MIDI;
+#else
 #include <Adafruit_TinyUSB_MIDI.h>
-
-Adafruit_TinyUSB_MIDI MIDI;
+// Other boards use the Adafruit TinyUSB MIDI driver
+Adafruit_USBD_MIDI MIDI;
+#endif
 
 int delayTime = 30;
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,26 @@ You can use the provided global `MIDI` object for simple sketches or create loca
       - macOS/Linux: `~/Documents/Arduino/libraries/`
 4. **Restart the Arduino IDE**: Restart your Arduino IDE to recognize the new library.
 
+## Using with UNO R4 / Minima / Nano R4
+
+The Renesas-based UNO R4 family ships with its own USBMIDI implementation.  Install the
+**Arduino UNO R4 Boards** package version **1.0.7 or later** from the Board Manager, then
+select the appropriate board under `Tools → Board`:
+
+* **UNO R4 Minima** – `Arduino UNO R4 Minima`
+* **UNO R4 WiFi** – `Arduino UNO R4 WiFi`
+* **Nano R4** – `Arduino Nano R4`
+
+These boards use the built-in `USBMIDI` class instead of the `Adafruit_USBD_MIDI` object
+shown in the other examples.  Instantiate `USBMIDI` in your sketch and call `MIDI.begin()`
+normally.
+
+After uploading the sketch the board will reboot and enumerate as a class‑compliant
+USB‑MIDI controller.  Check your operating system’s MIDI device list (e.g. **Audio MIDI
+Setup** on macOS or **Device Manager → Sound, video and game controllers** on Windows) to
+verify it appears.  If the device is not listed, press the reset button once to trigger
+USB re‑enumeration.
+
 
 ## Learn how to build your MIDI controllers
 


### PR DESCRIPTION
## Summary
- document setup for UNO R4, Minima and Nano R4 using built‑in USBMIDI
- explain how to check RA4 boards enumerate as class‑compliant MIDI devices
- add conditional code so RA4 boards use USBMIDI while others use Adafruit_USBD_MIDI

## Testing
- `g++ -std=c++17 -x c++ -I. -c Examples/MIDI_write/MIDI_write.ino` *(fails: Adafruit_TinyUSB.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a4596c090832a9e51bccd474ae01e