### PR TITLE
Provide global MIDI instance and simplify example

### DIFF
--- a/Adafruit_TinyUSB_MIDI.cpp
+++ b/Adafruit_TinyUSB_MIDI.cpp
@@ -2,7 +2,7 @@
 #include "Adafruit_TinyUSB_MIDI.h"
 
 // Initialize the global MIDI instance
-//Adafruit_TinyUSB_MIDI MIDI;
+Adafruit_TinyUSB_MIDI MIDI;
 
 #ifdef ADAFRUIT_TINYUSB_MIDI_RENESAS
 

--- a/Adafruit_TinyUSB_MIDI.h
+++ b/Adafruit_TinyUSB_MIDI.h
@@ -41,7 +41,7 @@ private:
     TinyUSBMIDI_Device _midi;
 };
 
-extern Adafruit_TinyUSB_MIDI MIDI;  // Global MIDI instance
+extern Adafruit_TinyUSB_MIDI MIDI;  // Global MIDI instance provided by the library
 
 // MIDI Input class definition for receiving MIDI messages
 #ifndef ADAFRUIT_TINYUSB_MIDI_RENESAS

--- a/Examples/MIDI_write/MIDI_write.ino
+++ b/Examples/MIDI_write/MIDI_write.ino
@@ -1,12 +1,4 @@
-#if defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_NANO_R4)
-// Renesas RA4 boards provide a built-in USBMIDI interface
-#include <USBMIDI.h>
-USBMIDI MIDI;
-#else
 #include <Adafruit_TinyUSB_MIDI.h>
-// Other boards use the Adafruit TinyUSB MIDI driver
-Adafruit_USBD_MIDI MIDI;
-#endif
 
 int delayTime = 30;
 


### PR DESCRIPTION
## Summary
- define library-wide `MIDI` object
- clarify header comment about global instance
- simplify `MIDI_write` example to rely on provided object

## Testing
- `g++ -std=c++17 -I/tmp -I. -include /tmp/Arduino.h -c Adafruit_TinyUSB_MIDI.cpp`
- `g++ -std=c++17 -I/tmp -I. -include /tmp/Arduino.h -x c++ -c Examples/MIDI_write/MIDI_write.ino -o /tmp/MIDI_write.o`


------
https://chatgpt.com/codex/tasks/task_e_689a4a76d780832ab78ab84b18b1135d