### PR TITLE
Refactor aftertouch API to channel pressure

### DIFF
--- a/Adafruit_TinyUSB_MIDI.cpp
+++ b/Adafruit_TinyUSB_MIDI.cpp
@@ -41,12 +41,8 @@ void Adafruit_TinyUSB_MIDI::sendSysEx(size_t length, uint8_t *data) {
     _midi.sendSysEx(data, length);
 }
 
-void Adafruit_TinyUSB_MIDI::sendChannelPressure(uint8_t pressure, uint8_t channel) {
+void Adafruit_TinyUSB_MIDI::sendAfterTouch(uint8_t pressure, uint8_t channel) {
     _midi.sendChannelPressure(pressure, channel);
-}
-
-void Adafruit_TinyUSB_MIDI::sendAfterTouch(uint8_t note, uint8_t pressure, uint8_t channel) {
-    _midi.sendAfterTouch(note, pressure, channel);
 }
 
 void Adafruit_TinyUSB_MIDI::sendPolyPressure(uint8_t note, uint8_t pressure, uint8_t channel) {
@@ -116,13 +112,8 @@ void Adafruit_TinyUSB_MIDI::sendSysEx(size_t length, uint8_t *data) {
     _midi.write(data, length);
 }
 
-void Adafruit_TinyUSB_MIDI::sendChannelPressure(uint8_t pressure, uint8_t channel) {
+void Adafruit_TinyUSB_MIDI::sendAfterTouch(uint8_t pressure, uint8_t channel) {
     uint8_t packet[4] = {static_cast<uint8_t>(0x0D), static_cast<uint8_t>(0xD0 | (channel & 0x0F)), pressure, 0};
-    _midi.writePacket(packet);
-}
-
-void Adafruit_TinyUSB_MIDI::sendAfterTouch(uint8_t note, uint8_t pressure, uint8_t channel) {
-    uint8_t packet[4] = {static_cast<uint8_t>(0x0A), static_cast<uint8_t>(0xA0 | (channel & 0x0F)), note, pressure};
     _midi.writePacket(packet);
 }
 

--- a/Adafruit_TinyUSB_MIDI.h
+++ b/Adafruit_TinyUSB_MIDI.h
@@ -25,8 +25,7 @@ public:
     void sendPitchBend(int16_t bendValue, uint8_t channel);
 
     void sendSysEx(size_t length, uint8_t *data);
-    void sendChannelPressure(uint8_t pressure, uint8_t channel);
-    void sendAfterTouch(uint8_t note, uint8_t pressure, uint8_t channel);
+    void sendAfterTouch(uint8_t pressure, uint8_t channel);
     void sendPolyPressure(uint8_t note, uint8_t pressure, uint8_t channel);
 
     void sendTimeCodeQuarterFrame(uint8_t typeNibble, uint8_t valuesNibble);

--- a/Examples/MIDI_write/MIDI_write.ino
+++ b/Examples/MIDI_write/MIDI_write.ino
@@ -35,15 +35,9 @@ void loop() {
     delay(delayTime);
   }
 
-  // Send Channel Pressure messages
+  // Send Aftertouch (Channel Pressure) messages
   for (int i = 0; i < 128; i++) {
-    MIDI.sendChannelPressure(i, 1);  // pressure value, channel
-    delay(delayTime);
-  }
-
-  // Send Aftertouch messages
-  for (int i = 36; i < 48; i++) {
-    MIDI.sendAfterTouch(i, 64, 1);  // note, pressure, channel
+    MIDI.sendAfterTouch(i, 1);  // pressure value, channel
     delay(delayTime);
   }
 


### PR DESCRIPTION
## Summary
- make `sendAfterTouch` emit channel pressure (0xD0)
- drop redundant `sendChannelPressure` helper
- update examples to call new `sendAfterTouch`

## Testing
- `g++ -std=c++17 -c Adafruit_TinyUSB_MIDI.cpp` *(fails: Adafruit_TinyUSB.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a50150f54832a8906c5f2e8bb631a