### PR TITLE
refactor: forward declare transport

### DIFF
--- a/Adafruit_TinyUSB_MIDI.cpp
+++ b/Adafruit_TinyUSB_MIDI.cpp
@@ -1,4 +1,9 @@
 // Adafruit TinyUSB MIDI implementation
+#if defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_NANO_R4)
+#include <USBMIDI.h>
+#else
+#include <Adafruit_TinyUSB.h>
+#endif
 #include "Adafruit_TinyUSB_MIDI.h"
 
 // Initialize the global MIDI instance

--- a/Adafruit_TinyUSB_MIDI.h
+++ b/Adafruit_TinyUSB_MIDI.h
@@ -1,12 +1,14 @@
 #ifndef ADAFRUIT_TINYUSB_MIDI_H
 #define ADAFRUIT_TINYUSB_MIDI_H
 
+#include <Arduino.h>
+
 #if defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_NANO_R4)
 #define ADAFRUIT_TINYUSB_MIDI_RENESAS
-#include <USBMIDI.h>
+class USBMIDI;
 using TinyUSBMIDI_Device = USBMIDI;
 #else
-#include <Adafruit_TinyUSB.h>
+class Adafruit_USBD_MIDI;
 using TinyUSBMIDI_Device = Adafruit_USBD_MIDI;
 #endif
 


### PR DESCRIPTION
## Summary
- forward declare USBMIDI and Adafruit_USBD_MIDI in the public header
- move concrete transport includes into the implementation file

## Testing
- `arduino-cli version` *(command not found)*
- `apt-get update` *(403 from archive.ubuntu.com)*
- `g++ -std=c++17 -c Adafruit_TinyUSB_MIDI.cpp` *(missing Adafruit_TinyUSB.h)*

------
https://chatgpt.com/codex/tasks/task_e_689a5016cf68832aa82034e5d5fef4ab