### PR TITLE
Remove duplicate parseMessage comment

### DIFF
--- a/Adafruit_TinyUSB_MIDI.cpp
+++ b/Adafruit_TinyUSB_MIDI.cpp
@@ -273,7 +273,6 @@ void Adafruit_TinyUSB_MIDI_Input::read() {
 }
 
 // Function to parse incoming MIDI messages
-// Function to parse incoming MIDI messages
 void Adafruit_TinyUSB_MIDI_Input::parseMessage(uint8_t *data, size_t length) {
     // If buffer starts with 0xF0, it's a full SysEx message
     if (data[0] == 0xF0) {


### PR DESCRIPTION
## Summary
- Remove redundant "Function to parse incoming MIDI messages" comment before `parseMessage`

## Testing
- `g++ -std=c++17 -I. -Itests/stubs tests/test_tinyusb_send_receive.cpp Adafruit_TinyUSB_MIDI.cpp -o build/test_tinyusb` *(fails: Arduino.h: No such file or directory)*
- `g++ -std=c++17 -I. -Itests/stubs -DADAFRUIT_TINYUSB_MIDI_RENESAS tests/test_renesas_send.cpp Adafruit_TinyUSB_MIDI.cpp -o build/test_renesas` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a57419a08832abca14e093b3fb65c