### PR TITLE
Document TinyUSB dependency and host build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ You can use the provided global `MIDI` object for simple sketches or create loca
       - macOS/Linux: `~/Documents/Arduino/libraries/`
 4. **Restart the Arduino IDE**: Restart your Arduino IDE to recognize the new library.
 
+## Building with g++
+
+This library depends on the [Adafruit TinyUSB Library](https://github.com/adafruit/Adafruit_TinyUSB_Arduino)
+for the `Adafruit_TinyUSB.h` core.  If you want to build the code on a host using `g++`,
+clone the TinyUSB library and add its `src` directory to your include path.  One way is to
+set the `CPLUS_INCLUDE_PATH` environment variable before compiling:
+
+```bash
+git clone https://github.com/adafruit/Adafruit_TinyUSB_Arduino.git
+export CPLUS_INCLUDE_PATH="$(pwd)/Adafruit_TinyUSB_Arduino/src:$CPLUS_INCLUDE_PATH"
+g++ -std=c++17 -c Adafruit_TinyUSB_MIDI.cpp
+```
+
 ## Using with UNO R4 / Minima / Nano R4
 
 The Renesas-based UNO R4 family ships with its own USBMIDI implementation.  Install the

--- a/library.properties
+++ b/library.properties
@@ -7,4 +7,4 @@ paragraph=This library simplifies sending MIDI messages via USB using the Adafru
 category=Communication
 url=https://github.com/silveirago/Adafruit_TinyUSB_MIDI
 architectures=*,renesas_uno,renesas_nano
-depends=Arduino_USB_MIDI
+depends=Arduino_USB_MIDI,Adafruit TinyUSB Library


### PR DESCRIPTION
## Summary
- Declare Adafruit TinyUSB Library as a dependency for Arduino builds
- Add host build instructions showing how to compile with g++ and the TinyUSB core

## Testing
- `./compile_examples.sh` *(fails: arduino-cli: command not found)*
- `g++ -std=c++17 -c Adafruit_TinyUSB_MIDI.cpp` with CPLUS_INCLUDE_PATH set to TinyUSB and an Arduino.h stub

------
https://chatgpt.com/codex/tasks/task_e_689a5743ae54832a87692346d3155f9d