### PR TITLE
Support board-specific MIDI transport selection

### DIFF
--- a/Adafruit_TinyUSB_MIDI.cpp
+++ b/Adafruit_TinyUSB_MIDI.cpp
@@ -1,17 +1,33 @@
 // Adafruit TinyUSB MIDI implementation
-#if defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_NANO_R4)
+#if defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_NANO_R4) || defined(ADAFRUIT_TINYUSB_MIDI_RENESAS)
 #include <USBMIDI.h>
 #else
 #include <Adafruit_TinyUSB.h>
 #endif
 #include "Adafruit_TinyUSB_MIDI.h"
 
-// Initialize the global MIDI instance
-Adafruit_TinyUSB_MIDI MIDI;
+// Helper factory that chooses an available transport at runtime.
+static TinyUSBMIDI_Device &selectTransport(uint8_t n_cables) {
+#ifdef ADAFRUIT_TINYUSB_MIDI_RENESAS
+    (void)n_cables;
+    static TinyUSBMIDI_Device transport;  // Renesas USBMIDI doesn't take cable count
+#else
+    static TinyUSBMIDI_Device transport(n_cables);
+#endif
+    return transport;
+}
+
+Adafruit_TinyUSB_MIDI Adafruit_TinyUSB_MIDI::makeDefault(uint8_t n_cables) {
+    return Adafruit_TinyUSB_MIDI(selectTransport(n_cables));
+}
+
+// Initialize the global MIDI instance using the factory
+Adafruit_TinyUSB_MIDI MIDI = Adafruit_TinyUSB_MIDI::makeDefault();
+
+Adafruit_TinyUSB_MIDI::Adafruit_TinyUSB_MIDI(TinyUSBMIDI_Device &transport)
+    : _midi(transport) {}
 
 #ifdef ADAFRUIT_TINYUSB_MIDI_RENESAS
-
-Adafruit_TinyUSB_MIDI::Adafruit_TinyUSB_MIDI(uint8_t n_cables) : _midi() {}
 
 bool Adafruit_TinyUSB_MIDI::begin() {
     _midi.begin();
@@ -75,8 +91,6 @@ void Adafruit_TinyUSB_MIDI::sendRealTime(uint8_t realTimeType) {
 }
 
 #else
-
-Adafruit_TinyUSB_MIDI::Adafruit_TinyUSB_MIDI(uint8_t n_cables) : _midi(n_cables) {}
 
 bool Adafruit_TinyUSB_MIDI::begin() {
     return _midi.begin();

--- a/Adafruit_TinyUSB_MIDI.h
+++ b/Adafruit_TinyUSB_MIDI.h
@@ -3,8 +3,10 @@
 
 #include <Arduino.h>
 
-#if defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_NANO_R4)
+#if defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_NANO_R4) || defined(ADAFRUIT_TINYUSB_MIDI_RENESAS)
+#ifndef ADAFRUIT_TINYUSB_MIDI_RENESAS
 #define ADAFRUIT_TINYUSB_MIDI_RENESAS
+#endif
 class USBMIDI;
 using TinyUSBMIDI_Device = USBMIDI;
 #else
@@ -15,7 +17,8 @@ using TinyUSBMIDI_Device = Adafruit_USBD_MIDI;
 // MIDI class definition for sending MIDI messages
 class Adafruit_TinyUSB_MIDI {
 public:
-    Adafruit_TinyUSB_MIDI(uint8_t n_cables = 1);
+    explicit Adafruit_TinyUSB_MIDI(TinyUSBMIDI_Device &transport);
+    static Adafruit_TinyUSB_MIDI makeDefault(uint8_t n_cables = 1);
 
     bool begin();
 
@@ -39,7 +42,7 @@ public:
     TinyUSBMIDI_Device& getMidiInstance();
 
 private:
-    TinyUSBMIDI_Device _midi;
+    TinyUSBMIDI_Device &_midi;
 };
 
 extern Adafruit_TinyUSB_MIDI MIDI;  // Global MIDI instance provided by the library

--- a/tests/test_renesas_send.cpp
+++ b/tests/test_renesas_send.cpp
@@ -1,9 +1,10 @@
 #include "Adafruit_TinyUSB_MIDI.h"
+#include <USBMIDI.h>
 #include <cassert>
 #include <iostream>
 
 int main() {
-  Adafruit_TinyUSB_MIDI midi;
+  Adafruit_TinyUSB_MIDI midi = Adafruit_TinyUSB_MIDI::makeDefault();
   midi.begin();
   midi.sendNoteOn(60, 127, 0);
   auto &inst = midi.getMidiInstance();

--- a/tests/test_tinyusb_send_receive.cpp
+++ b/tests/test_tinyusb_send_receive.cpp
@@ -1,4 +1,5 @@
 #include "Adafruit_TinyUSB_MIDI.h"
+#include <Adafruit_TinyUSB.h>
 #include <cassert>
 #include <iostream>
 
@@ -10,7 +11,7 @@ void onNoteOn(uint8_t channel, uint8_t note, uint8_t velocity) {
 }
 
 int main() {
-  Adafruit_TinyUSB_MIDI midi;
+  Adafruit_TinyUSB_MIDI midi = Adafruit_TinyUSB_MIDI::makeDefault();
   midi.begin();
   midi.sendNoteOn(0x3C, 0x7F, 0);
   auto &inst = midi.getMidiInstance();


### PR DESCRIPTION
## Summary
- add factory to choose USBMIDI or Adafruit TinyUSB transport based on board macros
- initialize global MIDI instance through the factory and use transport reference
- adjust tests for new factory API

## Testing
- `bash ./compile_examples.sh` *(fails: arduino-cli: command not found)*
- `g++ -std=c++17 -I. -Itests/stubs tests/test_tinyusb_send_receive.cpp Adafruit_TinyUSB_MIDI.cpp -o build/test_tinyusb && ./build/test_tinyusb`
- `g++ -std=c++17 -I. -Itests/stubs -DADAFRUIT_TINYUSB_MIDI_RENESAS tests/test_renesas_send.cpp Adafruit_TinyUSB_MIDI.cpp -o build/test_renesas && ./build/test_renesas`


------
https://chatgpt.com/codex/tasks/task_e_689a629f00b8832aa2aa4661509e0ba1