### PR TITLE
Refactor MIDI backend with transport interface

### DIFF
--- a/Adafruit_TinyUSB_MIDI.cpp
+++ b/Adafruit_TinyUSB_MIDI.cpp
@@ -1,108 +1,100 @@
 #include "Adafruit_TinyUSB_MIDI.h"
 
-// Initialize the global MIDI instance
-//Adafruit_TinyUSB_MIDI MIDI;
+#if defined(ARDUINO_ARCH_RENESAS)
+#include "RenesasUSBTransport.h"
+static RenesasUSBTransport _defaultTransport;
+#else
+#include "TinyUSBTransport.h"
+static TinyUSBTransport _defaultTransport;
+#endif
+
+Adafruit_TinyUSB_MIDI MIDI(_defaultTransport);
 
 // Adafruit_TinyUSB_MIDI constructor
-Adafruit_TinyUSB_MIDI::Adafruit_TinyUSB_MIDI(uint8_t n_cables) : _midi(n_cables) {}
+Adafruit_TinyUSB_MIDI::Adafruit_TinyUSB_MIDI(IMIDITransport &transport) : _transport(transport) {}
 
 // Begin MIDI interface
 bool Adafruit_TinyUSB_MIDI::begin() {
-    return _midi.begin();
+    return _transport.begin();
 }
 
-// Expose the MIDI instance
-Adafruit_USBD_MIDI& Adafruit_TinyUSB_MIDI::getMidiInstance() {
-    return _midi;
+// Expose the transport
+IMIDITransport& Adafruit_TinyUSB_MIDI::getTransport() {
+    return _transport;
 }
 
 // Implementing the sending functions
 
 void Adafruit_TinyUSB_MIDI::sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) {
-    uint8_t packet[4] = {static_cast<uint8_t>(0x09), static_cast<uint8_t>(0x90 | (channel & 0x0F)), note, velocity};
-    _midi.writePacket(packet);
+    _transport.sendNoteOn(note, velocity, channel);
 }
 
 void Adafruit_TinyUSB_MIDI::sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) {
-    uint8_t packet[4] = {static_cast<uint8_t>(0x08), static_cast<uint8_t>(0x80 | (channel & 0x0F)), note, velocity};
-    _midi.writePacket(packet);
+    _transport.sendNoteOff(note, velocity, channel);
 }
 
 // Control Change
 void Adafruit_TinyUSB_MIDI::sendControlChange(uint8_t controlNumber, uint8_t controlValue, uint8_t channel) {
-    uint8_t packet[4] = {static_cast<uint8_t>(0x0B), static_cast<uint8_t>(0xB0 | (channel & 0x0F)), controlNumber, controlValue};
-    _midi.writePacket(packet);
+    _transport.sendControlChange(controlNumber, controlValue, channel);
 }
 
 // Program Change
 void Adafruit_TinyUSB_MIDI::sendProgramChange(uint8_t programNumber, uint8_t channel) {
-    uint8_t packet[4] = {static_cast<uint8_t>(0x0C), static_cast<uint8_t>(0xC0 | (channel & 0x0F)), programNumber, 0};
-    _midi.writePacket(packet);
+    _transport.sendProgramChange(programNumber, channel);
 }
 
 // Pitch Bend
 void Adafruit_TinyUSB_MIDI::sendPitchBend(int16_t bendValue, uint8_t channel) {
-    uint8_t lsb = bendValue & 0x7F;
-    uint8_t msb = (bendValue >> 7) & 0x7F;
-    uint8_t packet[4] = {static_cast<uint8_t>(0x0E), static_cast<uint8_t>(0xE0 | (channel & 0x0F)), lsb, msb};
-    _midi.writePacket(packet);
+    _transport.sendPitchBend(bendValue, channel);
 }
 
 // SysEx
 void Adafruit_TinyUSB_MIDI::sendSysEx(size_t length, uint8_t *data) {
-    _midi.write(data, length);
+    _transport.sendSysEx(length, data);
 }
 
 // Channel Pressure
 void Adafruit_TinyUSB_MIDI::sendChannelPressure(uint8_t pressure, uint8_t channel) {
-    uint8_t packet[4] = {static_cast<uint8_t>(0x0D), static_cast<uint8_t>(0xD0 | (channel & 0x0F)), pressure, 0};
-    _midi.writePacket(packet);
+    _transport.sendChannelPressure(pressure, channel);
 }
 
 // Aftertouch
 void Adafruit_TinyUSB_MIDI::sendAfterTouch(uint8_t note, uint8_t pressure, uint8_t channel) {
-    uint8_t packet[4] = {static_cast<uint8_t>(0x0A), static_cast<uint8_t>(0xA0 | (channel & 0x0F)), note, pressure};
-    _midi.writePacket(packet);
+    _transport.sendAfterTouch(note, pressure, channel);
 }
 
 // Poly Pressure
 void Adafruit_TinyUSB_MIDI::sendPolyPressure(uint8_t note, uint8_t pressure, uint8_t channel) {
-    uint8_t packet[4] = {static_cast<uint8_t>(0x0A), static_cast<uint8_t>(0xA0 | (channel & 0x0F)), note, pressure};
-    _midi.writePacket(packet);
+    _transport.sendPolyPressure(note, pressure, channel);
 }
 
 // Time Code Quarter Frame
 void Adafruit_TinyUSB_MIDI::sendTimeCodeQuarterFrame(uint8_t typeNibble, uint8_t valuesNibble) {
-    uint8_t packet[4] = {static_cast<uint8_t>(0x02), static_cast<uint8_t>(0xF1), static_cast<uint8_t>((typeNibble << 4) | (valuesNibble & 0x0F)), 0};
-    _midi.writePacket(packet);
+    _transport.sendTimeCodeQuarterFrame(typeNibble, valuesNibble);
 }
 
 // Song Position
 void Adafruit_TinyUSB_MIDI::sendSongPosition(uint16_t beats) {
-    uint8_t packet[4] = {static_cast<uint8_t>(0x03), static_cast<uint8_t>(0xF2), static_cast<uint8_t>(beats & 0x7F), static_cast<uint8_t>((beats >> 7) & 0x7F)};
-    _midi.writePacket(packet);
+    _transport.sendSongPosition(beats);
 }
 
 // Song Select
 void Adafruit_TinyUSB_MIDI::sendSongSelect(uint8_t songNumber) {
-    uint8_t packet[4] = {static_cast<uint8_t>(0x02), static_cast<uint8_t>(0xF3), songNumber, 0};
-    _midi.writePacket(packet);
+    _transport.sendSongSelect(songNumber);
 }
 
 // Tune Request
 void Adafruit_TinyUSB_MIDI::sendTuneRequest() {
-    uint8_t packet[4] = {static_cast<uint8_t>(0x01), static_cast<uint8_t>(0xF6), 0, 0};
-    _midi.writePacket(packet);
+    _transport.sendTuneRequest();
 }
 
 // Real-Time Messages
 void Adafruit_TinyUSB_MIDI::sendRealTime(uint8_t realTimeType) {
-    uint8_t packet[4] = {static_cast<uint8_t>(0x01), realTimeType, 0, 0};
-    _midi.writePacket(packet);
+    _transport.sendRealTime(realTimeType);
 }
 
 // Adafruit_TinyUSB_MIDI_Input constructor
-Adafruit_TinyUSB_MIDI_Input::Adafruit_TinyUSB_MIDI_Input(Adafruit_USBD_MIDI &midiInstance) : _midi(midiInstance) {
+Adafruit_TinyUSB_MIDI_Input::Adafruit_TinyUSB_MIDI_Input(IMIDITransport &transport) : _transport(transport) {
     // Initialize callback pointers to nullptr
     handleNoteOn = nullptr;
     handleNoteOff = nullptr;
@@ -182,14 +174,13 @@ void Adafruit_TinyUSB_MIDI_Input::setHandleRealTime(void (*fptr)(uint8_t realTim
 void Adafruit_TinyUSB_MIDI_Input::read() {
     uint8_t data[4]; // Buffer for incoming MIDI data
 
-    while (_midi.available()) { // Check if there is data available
-        if (_midi.readPacket(data)) { // Read the incoming packet into the data buffer
+    while (_transport.available()) { // Check if there is data available
+        if (_transport.readPacket(data)) { // Read the incoming packet into the data buffer
             parseMessage(data, 4); // Parse the incoming message
         }
     }
 }
 
-// Function to parse incoming MIDI messages
 // Function to parse incoming MIDI messages
 void Adafruit_TinyUSB_MIDI_Input::parseMessage(uint8_t *data, size_t length) {
     uint8_t statusByte = data[1] & 0xF0;

--- a/Adafruit_TinyUSB_MIDI.h
+++ b/Adafruit_TinyUSB_MIDI.h
@@ -1,12 +1,12 @@
 #ifndef ADAFRUIT_TINYUSB_MIDI_H
 #define ADAFRUIT_TINYUSB_MIDI_H
 
-#include <Adafruit_TinyUSB.h>
+#include "IMIDITransport.h"
 
 // MIDI class definition for sending MIDI messages
 class Adafruit_TinyUSB_MIDI {
 public:
-    Adafruit_TinyUSB_MIDI(uint8_t n_cables = 1);  // Constructor
+    Adafruit_TinyUSB_MIDI(IMIDITransport &transport);  // Constructor
 
     bool begin();  // Initialize MIDI interface
 
@@ -28,10 +28,10 @@ public:
     void sendTuneRequest();
     void sendRealTime(uint8_t realTimeType);
 
-    Adafruit_USBD_MIDI& getMidiInstance();  // Expose MIDI instance for input handling
+    IMIDITransport& getTransport();  // Expose transport for input handling
 
 private:
-    Adafruit_USBD_MIDI _midi;
+    IMIDITransport &_transport;
 };
 
 extern Adafruit_TinyUSB_MIDI MIDI;  // Global MIDI instance
@@ -40,7 +40,7 @@ extern Adafruit_TinyUSB_MIDI MIDI;  // Global MIDI instance
 class Adafruit_TinyUSB_MIDI_Input {
 public:
     // Constructor
-    Adafruit_TinyUSB_MIDI_Input(Adafruit_USBD_MIDI &midiInstance);
+    Adafruit_TinyUSB_MIDI_Input(IMIDITransport &transport);
 
     // Functions to set callback functions
     void setHandleNoteOn(void (*fptr)(uint8_t channel, uint8_t note, uint8_t velocity));
@@ -62,8 +62,8 @@ public:
     void read();
 
 private:
-    // Reference to MIDI instance
-    Adafruit_USBD_MIDI &_midi;
+    // Reference to MIDI transport
+    IMIDITransport &_transport;
 
     // Callback function pointers
     void (*handleNoteOn)(uint8_t channel, uint8_t note, uint8_t velocity);

--- a/Examples/MIDI_read/MIDI_read.ino
+++ b/Examples/MIDI_read/MIDI_read.ino
@@ -1,7 +1,7 @@
 #include <Adafruit_TinyUSB_MIDI.h>
 
 // Global instance for MIDI Input
-Adafruit_TinyUSB_MIDI_Input MIDI_Input(MIDI.getMidiInstance());
+Adafruit_TinyUSB_MIDI_Input MIDI_Input(MIDI.getTransport());
 
 bool ledState = false;  // Variable to keep track of LED state
 

--- a/Examples/MIDI_write/MIDI_write.ino
+++ b/Examples/MIDI_write/MIDI_write.ino
@@ -1,7 +1,5 @@
 #include <Adafruit_TinyUSB_MIDI.h>
 
-Adafruit_TinyUSB_MIDI MIDI;
-
 int delayTime = 30;
 
 void setup() {

--- a/IMIDITransport.h
+++ b/IMIDITransport.h
@@ -1,0 +1,31 @@
+#ifndef IMIDI_TRANSPORT_H
+#define IMIDI_TRANSPORT_H
+
+#include <Arduino.h>
+#include <stddef.h>
+
+class IMIDITransport {
+public:
+    virtual ~IMIDITransport() {}
+
+    virtual bool begin() = 0;
+    virtual bool available() = 0;
+    virtual bool readPacket(uint8_t *data) = 0;
+
+    virtual void sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) = 0;
+    virtual void sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) = 0;
+    virtual void sendControlChange(uint8_t controlNumber, uint8_t controlValue, uint8_t channel) = 0;
+    virtual void sendProgramChange(uint8_t programNumber, uint8_t channel) = 0;
+    virtual void sendPitchBend(int16_t bendValue, uint8_t channel) = 0;
+    virtual void sendSysEx(size_t length, uint8_t *data) = 0;
+    virtual void sendChannelPressure(uint8_t pressure, uint8_t channel) = 0;
+    virtual void sendAfterTouch(uint8_t note, uint8_t pressure, uint8_t channel) = 0;
+    virtual void sendPolyPressure(uint8_t note, uint8_t pressure, uint8_t channel) = 0;
+    virtual void sendTimeCodeQuarterFrame(uint8_t typeNibble, uint8_t valuesNibble) = 0;
+    virtual void sendSongPosition(uint16_t beats) = 0;
+    virtual void sendSongSelect(uint8_t songNumber) = 0;
+    virtual void sendTuneRequest() = 0;
+    virtual void sendRealTime(uint8_t realTimeType) = 0;
+};
+
+#endif // IMIDI_TRANSPORT_H

--- a/RenesasUSBTransport.cpp
+++ b/RenesasUSBTransport.cpp
@@ -1,0 +1,86 @@
+#include "RenesasUSBTransport.h"
+
+#if defined(ARDUINO_ARCH_RENESAS)
+
+RenesasUSBTransport::RenesasUSBTransport(uint8_t n_cables) : _midi(n_cables) {}
+
+bool RenesasUSBTransport::begin() { return _midi.begin(); }
+
+bool RenesasUSBTransport::available() { return _midi.available(); }
+
+bool RenesasUSBTransport::readPacket(uint8_t *data) { return _midi.readPacket(data); }
+
+void RenesasUSBTransport::sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x09), static_cast<uint8_t>(0x90 | (channel & 0x0F)), note, velocity};
+    _midi.writePacket(packet);
+}
+
+void RenesasUSBTransport::sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x08), static_cast<uint8_t>(0x80 | (channel & 0x0F)), note, velocity};
+    _midi.writePacket(packet);
+}
+
+void RenesasUSBTransport::sendControlChange(uint8_t controlNumber, uint8_t controlValue, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x0B), static_cast<uint8_t>(0xB0 | (channel & 0x0F)), controlNumber, controlValue};
+    _midi.writePacket(packet);
+}
+
+void RenesasUSBTransport::sendProgramChange(uint8_t programNumber, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x0C), static_cast<uint8_t>(0xC0 | (channel & 0x0F)), programNumber, 0};
+    _midi.writePacket(packet);
+}
+
+void RenesasUSBTransport::sendPitchBend(int16_t bendValue, uint8_t channel) {
+    uint8_t lsb = bendValue & 0x7F;
+    uint8_t msb = (bendValue >> 7) & 0x7F;
+    uint8_t packet[4] = {static_cast<uint8_t>(0x0E), static_cast<uint8_t>(0xE0 | (channel & 0x0F)), lsb, msb};
+    _midi.writePacket(packet);
+}
+
+void RenesasUSBTransport::sendSysEx(size_t length, uint8_t *data) {
+    _midi.write(data, length);
+}
+
+void RenesasUSBTransport::sendChannelPressure(uint8_t pressure, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x0D), static_cast<uint8_t>(0xD0 | (channel & 0x0F)), pressure, 0};
+    _midi.writePacket(packet);
+}
+
+void RenesasUSBTransport::sendAfterTouch(uint8_t note, uint8_t pressure, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x0A), static_cast<uint8_t>(0xA0 | (channel & 0x0F)), note, pressure};
+    _midi.writePacket(packet);
+}
+
+void RenesasUSBTransport::sendPolyPressure(uint8_t note, uint8_t pressure, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x0A), static_cast<uint8_t>(0xA0 | (channel & 0x0F)), note, pressure};
+    _midi.writePacket(packet);
+}
+
+void RenesasUSBTransport::sendTimeCodeQuarterFrame(uint8_t typeNibble, uint8_t valuesNibble) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x02), static_cast<uint8_t>(0xF1), static_cast<uint8_t>((typeNibble << 4) | (valuesNibble & 0x0F)), 0};
+    _midi.writePacket(packet);
+}
+
+void RenesasUSBTransport::sendSongPosition(uint16_t beats) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x03), static_cast<uint8_t>(0xF2), static_cast<uint8_t>(beats & 0x7F), static_cast<uint8_t>((beats >> 7) & 0x7F)};
+    _midi.writePacket(packet);
+}
+
+void RenesasUSBTransport::sendSongSelect(uint8_t songNumber) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x02), static_cast<uint8_t>(0xF3), songNumber, 0};
+    _midi.writePacket(packet);
+}
+
+void RenesasUSBTransport::sendTuneRequest() {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x01), static_cast<uint8_t>(0xF6), 0, 0};
+    _midi.writePacket(packet);
+}
+
+void RenesasUSBTransport::sendRealTime(uint8_t realTimeType) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x01), realTimeType, 0, 0};
+    _midi.writePacket(packet);
+}
+
+USBMIDI& RenesasUSBTransport::getMIDI() { return _midi; }
+
+#endif

--- a/RenesasUSBTransport.h
+++ b/RenesasUSBTransport.h
@@ -1,0 +1,40 @@
+#ifndef RENESAS_USB_TRANSPORT_H
+#define RENESAS_USB_TRANSPORT_H
+
+#include "IMIDITransport.h"
+
+#if defined(ARDUINO_ARCH_RENESAS)
+#include <USB-MIDI.h>
+
+class RenesasUSBTransport : public IMIDITransport {
+public:
+    RenesasUSBTransport(uint8_t n_cables = 1);
+
+    bool begin() override;
+    bool available() override;
+    bool readPacket(uint8_t *data) override;
+
+    void sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) override;
+    void sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) override;
+    void sendControlChange(uint8_t controlNumber, uint8_t controlValue, uint8_t channel) override;
+    void sendProgramChange(uint8_t programNumber, uint8_t channel) override;
+    void sendPitchBend(int16_t bendValue, uint8_t channel) override;
+    void sendSysEx(size_t length, uint8_t *data) override;
+    void sendChannelPressure(uint8_t pressure, uint8_t channel) override;
+    void sendAfterTouch(uint8_t note, uint8_t pressure, uint8_t channel) override;
+    void sendPolyPressure(uint8_t note, uint8_t pressure, uint8_t channel) override;
+    void sendTimeCodeQuarterFrame(uint8_t typeNibble, uint8_t valuesNibble) override;
+    void sendSongPosition(uint16_t beats) override;
+    void sendSongSelect(uint8_t songNumber) override;
+    void sendTuneRequest() override;
+    void sendRealTime(uint8_t realTimeType) override;
+
+    USBMIDI& getMIDI();
+
+private:
+    USBMIDI _midi;
+};
+
+#endif // ARDUINO_ARCH_RENESAS
+
+#endif // RENESAS_USB_TRANSPORT_H

--- a/TinyUSBTransport.cpp
+++ b/TinyUSBTransport.cpp
@@ -1,0 +1,82 @@
+#include "TinyUSBTransport.h"
+
+TinyUSBTransport::TinyUSBTransport(uint8_t n_cables) : _midi(n_cables) {}
+
+bool TinyUSBTransport::begin() { return _midi.begin(); }
+
+bool TinyUSBTransport::available() { return _midi.available(); }
+
+bool TinyUSBTransport::readPacket(uint8_t *data) { return _midi.readPacket(data); }
+
+void TinyUSBTransport::sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x09), static_cast<uint8_t>(0x90 | (channel & 0x0F)), note, velocity};
+    _midi.writePacket(packet);
+}
+
+void TinyUSBTransport::sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x08), static_cast<uint8_t>(0x80 | (channel & 0x0F)), note, velocity};
+    _midi.writePacket(packet);
+}
+
+void TinyUSBTransport::sendControlChange(uint8_t controlNumber, uint8_t controlValue, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x0B), static_cast<uint8_t>(0xB0 | (channel & 0x0F)), controlNumber, controlValue};
+    _midi.writePacket(packet);
+}
+
+void TinyUSBTransport::sendProgramChange(uint8_t programNumber, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x0C), static_cast<uint8_t>(0xC0 | (channel & 0x0F)), programNumber, 0};
+    _midi.writePacket(packet);
+}
+
+void TinyUSBTransport::sendPitchBend(int16_t bendValue, uint8_t channel) {
+    uint8_t lsb = bendValue & 0x7F;
+    uint8_t msb = (bendValue >> 7) & 0x7F;
+    uint8_t packet[4] = {static_cast<uint8_t>(0x0E), static_cast<uint8_t>(0xE0 | (channel & 0x0F)), lsb, msb};
+    _midi.writePacket(packet);
+}
+
+void TinyUSBTransport::sendSysEx(size_t length, uint8_t *data) {
+    _midi.write(data, length);
+}
+
+void TinyUSBTransport::sendChannelPressure(uint8_t pressure, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x0D), static_cast<uint8_t>(0xD0 | (channel & 0x0F)), pressure, 0};
+    _midi.writePacket(packet);
+}
+
+void TinyUSBTransport::sendAfterTouch(uint8_t note, uint8_t pressure, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x0A), static_cast<uint8_t>(0xA0 | (channel & 0x0F)), note, pressure};
+    _midi.writePacket(packet);
+}
+
+void TinyUSBTransport::sendPolyPressure(uint8_t note, uint8_t pressure, uint8_t channel) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x0A), static_cast<uint8_t>(0xA0 | (channel & 0x0F)), note, pressure};
+    _midi.writePacket(packet);
+}
+
+void TinyUSBTransport::sendTimeCodeQuarterFrame(uint8_t typeNibble, uint8_t valuesNibble) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x02), static_cast<uint8_t>(0xF1), static_cast<uint8_t>((typeNibble << 4) | (valuesNibble & 0x0F)), 0};
+    _midi.writePacket(packet);
+}
+
+void TinyUSBTransport::sendSongPosition(uint16_t beats) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x03), static_cast<uint8_t>(0xF2), static_cast<uint8_t>(beats & 0x7F), static_cast<uint8_t>((beats >> 7) & 0x7F)};
+    _midi.writePacket(packet);
+}
+
+void TinyUSBTransport::sendSongSelect(uint8_t songNumber) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x02), static_cast<uint8_t>(0xF3), songNumber, 0};
+    _midi.writePacket(packet);
+}
+
+void TinyUSBTransport::sendTuneRequest() {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x01), static_cast<uint8_t>(0xF6), 0, 0};
+    _midi.writePacket(packet);
+}
+
+void TinyUSBTransport::sendRealTime(uint8_t realTimeType) {
+    uint8_t packet[4] = {static_cast<uint8_t>(0x01), realTimeType, 0, 0};
+    _midi.writePacket(packet);
+}
+
+Adafruit_USBD_MIDI& TinyUSBTransport::getMIDI() { return _midi; }

--- a/TinyUSBTransport.h
+++ b/TinyUSBTransport.h
@@ -1,0 +1,36 @@
+#ifndef TINYUSB_TRANSPORT_H
+#define TINYUSB_TRANSPORT_H
+
+#include <Adafruit_TinyUSB.h>
+#include "IMIDITransport.h"
+
+class TinyUSBTransport : public IMIDITransport {
+public:
+    TinyUSBTransport(uint8_t n_cables = 1);
+
+    bool begin() override;
+    bool available() override;
+    bool readPacket(uint8_t *data) override;
+
+    void sendNoteOn(uint8_t note, uint8_t velocity, uint8_t channel) override;
+    void sendNoteOff(uint8_t note, uint8_t velocity, uint8_t channel) override;
+    void sendControlChange(uint8_t controlNumber, uint8_t controlValue, uint8_t channel) override;
+    void sendProgramChange(uint8_t programNumber, uint8_t channel) override;
+    void sendPitchBend(int16_t bendValue, uint8_t channel) override;
+    void sendSysEx(size_t length, uint8_t *data) override;
+    void sendChannelPressure(uint8_t pressure, uint8_t channel) override;
+    void sendAfterTouch(uint8_t note, uint8_t pressure, uint8_t channel) override;
+    void sendPolyPressure(uint8_t note, uint8_t pressure, uint8_t channel) override;
+    void sendTimeCodeQuarterFrame(uint8_t typeNibble, uint8_t valuesNibble) override;
+    void sendSongPosition(uint16_t beats) override;
+    void sendSongSelect(uint8_t songNumber) override;
+    void sendTuneRequest() override;
+    void sendRealTime(uint8_t realTimeType) override;
+
+    Adafruit_USBD_MIDI& getMIDI();
+
+private:
+    Adafruit_USBD_MIDI _midi;
+};
+
+#endif // TINYUSB_TRANSPORT_H


### PR DESCRIPTION
## Summary
- add `IMIDITransport` interface for backend abstraction
- implement `TinyUSBTransport` and `RenesasUSBTransport`
- refactor `Adafruit_TinyUSB_MIDI` and examples to accept transport implementations
- move transport includes out of the public header to keep it backend-agnostic

## Testing
- `g++ -std=c++11 -c Adafruit_TinyUSB_MIDI.cpp` *(fails: Arduino.h: No such file or directory)*
- `g++ -std=c++11 -c TinyUSBTransport.cpp` *(fails: Adafruit_TinyUSB.h: No such file or directory)*
- `g++ -std=c++11 -c RenesasUSBTransport.cpp` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689a459930d8832aa56b59fde70e42b8