### PR TITLE
Make sendSysEx accept const data pointer

### DIFF
--- a/Adafruit_TinyUSB_MIDI.cpp
+++ b/Adafruit_TinyUSB_MIDI.cpp
@@ -58,7 +58,7 @@ void Adafruit_TinyUSB_MIDI::sendPitchBend(int16_t bendValue, uint8_t channel) {
     _midi.sendPitchBend(bendValue, channel);
 }
 
-void Adafruit_TinyUSB_MIDI::sendSysEx(size_t length, uint8_t *data) {
+void Adafruit_TinyUSB_MIDI::sendSysEx(size_t length, const uint8_t *data) {
     _midi.sendSysEx(data, length);
 }
 
@@ -127,7 +127,7 @@ void Adafruit_TinyUSB_MIDI::sendPitchBend(int16_t bendValue, uint8_t channel) {
     _midi.writePacket(packet);
 }
 
-void Adafruit_TinyUSB_MIDI::sendSysEx(size_t length, uint8_t *data) {
+void Adafruit_TinyUSB_MIDI::sendSysEx(size_t length, const uint8_t *data) {
     _midi.write(data, length);
 }
 

--- a/Adafruit_TinyUSB_MIDI.h
+++ b/Adafruit_TinyUSB_MIDI.h
@@ -25,7 +25,7 @@ public:
     void sendControlChange(uint8_t controlNumber, uint8_t controlValue, uint8_t channel);
     void sendProgramChange(uint8_t programNumber, uint8_t channel);
     void sendPitchBend(int16_t bendValue, uint8_t channel);
-    void sendSysEx(size_t length, uint8_t *data);
+    void sendSysEx(size_t length, const uint8_t *data);
     void sendAfterTouch(uint8_t pressure, uint8_t channel);
     void sendPolyPressure(uint8_t note, uint8_t pressure, uint8_t channel);
     void sendTimeCodeQuarterFrame(uint8_t typeNibble, uint8_t valuesNibble);

--- a/Examples/MIDI_write/MIDI_write.ino
+++ b/Examples/MIDI_write/MIDI_write.ino
@@ -48,7 +48,7 @@ void loop() {
   }
 
   // Send SysEx messages
-  uint8_t sysexData[3] = {0x7E, 0x7F, 0x09};  // Example SysEx data
+  const uint8_t sysexData[3] = {0x7E, 0x7F, 0x09};  // Example SysEx data
   MIDI.sendSysEx(3, sysexData);
   delay(delayTime);
 

--- a/tests/stubs/USBMIDI.h
+++ b/tests/stubs/USBMIDI.h
@@ -23,7 +23,7 @@ public:
   void sendPitchBend(int16_t bendValue, uint8_t channel) {
     sent.push_back({static_cast<uint8_t>(0xE0 | (channel & 0x0F)), static_cast<uint8_t>(bendValue & 0x7F), static_cast<uint8_t>((bendValue >> 7) & 0x7F)});
   }
-  void sendSysEx(uint8_t *data, size_t length) {}
+  void sendSysEx(const uint8_t *data, size_t length) {}
   void sendChannelPressure(uint8_t pressure, uint8_t channel) {
     sent.push_back({static_cast<uint8_t>(0xD0 | (channel & 0x0F)), pressure, 0});
   }


### PR DESCRIPTION
## Summary
- allow sending SysEx messages from const memory by changing `sendSysEx` to take `const uint8_t*`
- update MIDI write example and USBMIDI stub for const SysEx data

## Testing
- `g++ -std=c++17 tests/test_tinyusb_send_receive.cpp Adafruit_TinyUSB_MIDI.cpp -Itests/stubs -I. -o tests/test_tinyusb_send_receive && ./tests/test_tinyusb_send_receive`
- `g++ -std=c++17 tests/test_sysex_receive.cpp Adafruit_TinyUSB_MIDI.cpp -Itests/stubs -I. -o tests/test_sysex_receive && ./tests/test_sysex_receive`
- `g++ -std=c++17 tests/test_renesas_send.cpp Adafruit_TinyUSB_MIDI.cpp -Itests/stubs -I. -DADAFRUIT_TINYUSB_MIDI_RENESAS -o tests/test_renesas_send && ./tests/test_renesas_send`


------
https://chatgpt.com/codex/tasks/task_e_689a828a2310832a81b0a5bbfc443491