### PR TITLE
Add SysEx host test to build script

### DIFF
--- a/compile_examples.sh
+++ b/compile_examples.sh
@@ -17,8 +17,12 @@ mkdir -p build
 
 echo "Compiling TinyUSB host tests"
 g++ -std=c++17 -I. -Itests/stubs tests/test_tinyusb_send_receive.cpp Adafruit_TinyUSB_MIDI.cpp -o build/test_tinyusb
-./build/test_tinyusb
+./build/test_tinyusb || exit 1
+
+echo "Compiling SysEx host tests"
+g++ -std=c++17 -I. -Itests/stubs tests/test_sysex_receive.cpp Adafruit_TinyUSB_MIDI.cpp -o build/test_sysex
+./build/test_sysex || exit 1
 
 echo "Compiling Renesas host tests"
 g++ -std=c++17 -I. -Itests/stubs -DADAFRUIT_TINYUSB_MIDI_RENESAS tests/test_renesas_send.cpp Adafruit_TinyUSB_MIDI.cpp -o build/test_renesas
-./build/test_renesas
+./build/test_renesas || exit 1


### PR DESCRIPTION
## Summary
- add g++ compile/run block for SysEx receive host test
- stop on failing test with `|| exit 1`

## Testing
- `bash compile_examples.sh` *(fails: arduino-cli: command not found)*
- `g++ -std=c++17 -I. -Itests/stubs tests/test_sysex_receive.cpp Adafruit_TinyUSB_MIDI.cpp -o /tmp/test_sysex && /tmp/test_sysex` *(fails: no matching function for call to ‘Adafruit_TinyUSB_MIDI::Adafruit_TinyUSB_MIDI()’)*
- `g++ -std=c++17 -I. -Itests/stubs tests/test_tinyusb_send_receive.cpp Adafruit_TinyUSB_MIDI.cpp -o /tmp/test_tinyusb && /tmp/test_tinyusb`
- `g++ -std=c++17 -I. -Itests/stubs -DADAFRUIT_TINYUSB_MIDI_RENESAS tests/test_renesas_send.cpp Adafruit_TinyUSB_MIDI.cpp -o /tmp/test_renesas && /tmp/test_renesas`


------
https://chatgpt.com/codex/tasks/task_e_689a8291654c832ab5aae0510534bb0a