### PR TITLE
Use makeDefault factory in SysEx test

### DIFF
--- a/tests/test_sysex_receive.cpp
+++ b/tests/test_sysex_receive.cpp
@@ -1,4 +1,5 @@
 #include "Adafruit_TinyUSB_MIDI.h"
+#include <Adafruit_TinyUSB.h>
 #include <cassert>
 #include <cstring>
 #include <iostream>
@@ -12,7 +13,7 @@ void onSysEx(size_t len, uint8_t *data) {
 }
 
 int main() {
-  Adafruit_TinyUSB_MIDI midi;
+  auto midi = Adafruit_TinyUSB_MIDI::makeDefault();
   midi.begin();
   auto &inst = midi.getMidiInstance();
 


### PR DESCRIPTION
## Summary
- switch SysEx receive test to use `Adafruit_TinyUSB_MIDI::makeDefault`
- include TinyUSB host stubs so the test builds outside Arduino

## Testing
- `g++ -std=c++17 -I. -Itests/stubs tests/test_sysex_receive.cpp Adafruit_TinyUSB_MIDI.cpp -o build/test_sysex`
- `./build/test_sysex`
- `g++ -std=c++17 -I. -Itests/stubs tests/test_tinyusb_send_receive.cpp Adafruit_TinyUSB_MIDI.cpp -o build/test_tinyusb`
- `./build/test_tinyusb`
- `g++ -std=c++17 -I. -Itests/stubs -DADAFRUIT_TINYUSB_MIDI_RENESAS tests/test_renesas_send.cpp Adafruit_TinyUSB_MIDI.cpp -o build/test_renesas`
- `./build/test_renesas`


------
https://chatgpt.com/codex/tasks/task_e_689a82948228832a91e6be4c20acb8ab