### PR TITLE
Remove unused AfterTouch callback

### DIFF
--- a/Adafruit_TinyUSB_MIDI.cpp
+++ b/Adafruit_TinyUSB_MIDI.cpp
@@ -175,7 +175,7 @@ Adafruit_TinyUSB_MIDI_Input::Adafruit_TinyUSB_MIDI_Input(TinyUSBMIDI_Device &mid
       handleNoteOn(nullptr), handleNoteOff(nullptr),
       handleControlChange(nullptr), handleProgramChange(nullptr),
       handlePitchBend(nullptr), handleChannelPressure(nullptr),
-      handleAfterTouch(nullptr), handlePolyPressure(nullptr),
+      handlePolyPressure(nullptr),
       handleSysEx(nullptr), handleTimeCodeQuarterFrame(nullptr),
       handleSongPosition(nullptr), handleSongSelect(nullptr),
       handleTuneRequest(nullptr), handleRealTime(nullptr) {}
@@ -186,7 +186,6 @@ void Adafruit_TinyUSB_MIDI_Input::setHandleControlChange(void (*fptr)(uint8_t, u
 void Adafruit_TinyUSB_MIDI_Input::setHandleProgramChange(void (*fptr)(uint8_t, uint8_t)) { handleProgramChange = fptr; }
 void Adafruit_TinyUSB_MIDI_Input::setHandlePitchBend(void (*fptr)(uint8_t, int16_t)) { handlePitchBend = fptr; }
 void Adafruit_TinyUSB_MIDI_Input::setHandleChannelPressure(void (*fptr)(uint8_t, uint8_t)) { handleChannelPressure = fptr; }
-void Adafruit_TinyUSB_MIDI_Input::setHandleAfterTouch(void (*fptr)(uint8_t, uint8_t, uint8_t)) { handleAfterTouch = fptr; }
 void Adafruit_TinyUSB_MIDI_Input::setHandlePolyPressure(void (*fptr)(uint8_t, uint8_t, uint8_t)) { handlePolyPressure = fptr; }
 void Adafruit_TinyUSB_MIDI_Input::setHandleSysEx(void (*fptr)(size_t, uint8_t *)) { handleSysEx = fptr; }
 void Adafruit_TinyUSB_MIDI_Input::setHandleTimeCodeQuarterFrame(void (*fptr)(uint8_t, uint8_t)) { handleTimeCodeQuarterFrame = fptr; }

--- a/Adafruit_TinyUSB_MIDI.h
+++ b/Adafruit_TinyUSB_MIDI.h
@@ -53,7 +53,6 @@ public:
     void setHandleProgramChange(void (*fptr)(uint8_t channel, uint8_t programNumber));
     void setHandlePitchBend(void (*fptr)(uint8_t channel, int16_t bendValue));
     void setHandleChannelPressure(void (*fptr)(uint8_t channel, uint8_t pressure));
-    void setHandleAfterTouch(void (*fptr)(uint8_t channel, uint8_t note, uint8_t pressure));
     void setHandlePolyPressure(void (*fptr)(uint8_t channel, uint8_t note, uint8_t pressure));
     void setHandleSysEx(void (*fptr)(size_t length, uint8_t *data));
     void setHandleTimeCodeQuarterFrame(void (*fptr)(uint8_t typeNibble, uint8_t valuesNibble));
@@ -72,7 +71,6 @@ private:
     void (*handleProgramChange)(uint8_t, uint8_t);
     void (*handlePitchBend)(uint8_t, int16_t);
     void (*handleChannelPressure)(uint8_t, uint8_t);
-    void (*handleAfterTouch)(uint8_t, uint8_t, uint8_t);
     void (*handlePolyPressure)(uint8_t, uint8_t, uint8_t);
     void (*handleSysEx)(size_t, uint8_t *);
     void (*handleTimeCodeQuarterFrame)(uint8_t, uint8_t);

--- a/Examples/MIDI_read/MIDI_read.ino
+++ b/Examples/MIDI_read/MIDI_read.ino
@@ -19,7 +19,6 @@ void setup() {
   MIDI_Input.setHandleProgramChange(handleProgramChange);
   MIDI_Input.setHandlePitchBend(handlePitchBend);
   MIDI_Input.setHandleChannelPressure(handleChannelPressure);
-  MIDI_Input.setHandleAfterTouch(handleAfterTouch);
   MIDI_Input.setHandlePolyPressure(handlePolyPressure);
   MIDI_Input.setHandleSysEx(handleSysEx);
   MIDI_Input.setHandleTimeCodeQuarterFrame(handleTimeCodeQuarterFrame);
@@ -123,20 +122,6 @@ void handlePolyPressure(uint8_t channel, uint8_t note, uint8_t pressure) {
   // Toggle LED state
   toggleLED();
 }
-
-// Callback function for handling Aftertouch messages
-void handleAfterTouch(uint8_t channel, uint8_t note, uint8_t pressure) {
-  Serial.print("Aftertouch received. Channel: ");
-  Serial.print(channel);
-  Serial.print(", Note: ");
-  Serial.print(note);
-  Serial.print(", Pressure: ");
-  Serial.println(pressure);
-
-  // Toggle LED state
-  toggleLED();
-}
-
 
 // Callback function for handling System Exclusive (SysEx) messages
 void handleSysEx(size_t length, uint8_t *data) {


### PR DESCRIPTION
## Summary
- drop unused `handleAfterTouch` callback from input API
- update MIDI_read example to rely on `handleChannelPressure` and `handlePolyPressure`

## Testing
- `g++ -std=c++17 -I. -Itests/stubs tests/test_tinyusb_send_receive.cpp Adafruit_TinyUSB_MIDI.cpp -o build/test_tinyusb && ./build/test_tinyusb`
- `g++ -std=c++17 -I. -Itests/stubs -DADAFRUIT_TINYUSB_MIDI_RENESAS tests/test_renesas_send.cpp Adafruit_TinyUSB_MIDI.cpp -o build/test_renesas && ./build/test_renesas`


------
https://chatgpt.com/codex/tasks/task_e_689a829752fc832a87afdd56bb8e5eb6