### PR TITLE
Handle zero bytes in SysEx payload

### DIFF
--- a/Adafruit_TinyUSB_MIDI.cpp
+++ b/Adafruit_TinyUSB_MIDI.cpp
@@ -210,7 +210,7 @@ void Adafruit_TinyUSB_MIDI_Input::parseMessage(uint8_t *data, size_t length) {
 
     for (size_t i = 1; i < 4; ++i) {
         uint8_t b = data[i];
-        if (b == 0) continue;
+        if (b == 0 && !_inSysEx) continue;
 
         if (b >= 0xF8) { if (handleRealTime) handleRealTime(b); continue; }
 

--- a/tests/test_sysex_zero_byte.cpp
+++ b/tests/test_sysex_zero_byte.cpp
@@ -20,16 +20,15 @@ int main() {
   Adafruit_TinyUSB_MIDI_Input input(midi.getMidiInstance());
   input.setHandleSysEx(onSysEx);
 
-  // queue a SysEx message split across three packets
-  inst.queueInput({0x04, 0xF0, 0x01, 0x02});
-  inst.queueInput({0x04, 0x03, 0x04, 0x05});
-  inst.queueInput({0x05, 0xF7, 0x00, 0x00});
+  // SysEx message containing a zero byte in the payload: F0 01 00 02 F7
+  inst.queueInput({0x04, 0xF0, 0x01, 0x00});
+  inst.queueInput({0x06, 0x02, 0xF7, 0x00});
 
   input.read();
 
-  assert(sysexLen == 7);
-  uint8_t expected[7] = {0xF0,0x01,0x02,0x03,0x04,0x05,0xF7};
-  assert(std::memcmp(sysexData, expected, 7) == 0);
-  std::cout << "SysEx receive test passed" << std::endl;
+  assert(sysexLen == 5);
+  uint8_t expected[5] = {0xF0, 0x01, 0x00, 0x02, 0xF7};
+  assert(std::memcmp(sysexData, expected, 5) == 0);
+  std::cout << "SysEx zero byte test passed" << std::endl;
   return 0;
 }


### PR DESCRIPTION
## Summary
- Capture zero-valued bytes during SysEx parsing so messages with 0x00 are preserved
- Add regression test covering SysEx payloads containing 0x00
- Fix existing SysEx receive test setup

## Testing
- `g++ -std=c++17 -I. -Itests/stubs tests/test_tinyusb_send_receive.cpp Adafruit_TinyUSB_MIDI.cpp -o /tmp/test_tinyusb_send_receive && /tmp/test_tinyusb_send_receive`
- `g++ -std=c++17 -I. -Itests/stubs tests/test_sysex_receive.cpp Adafruit_TinyUSB_MIDI.cpp -o /tmp/test_sysex_receive && /tmp/test_sysex_receive`
- `g++ -std=c++17 -I. -Itests/stubs -DADAFRUIT_TINYUSB_MIDI_RENESAS tests/test_renesas_send.cpp Adafruit_TinyUSB_MIDI.cpp -o /tmp/test_renesas_send && /tmp/test_renesas_send`
- `g++ -std=c++17 -I. -Itests/stubs tests/test_sysex_zero_byte.cpp Adafruit_TinyUSB_MIDI.cpp -o /tmp/test_sysex_zero_byte && /tmp/test_sysex_zero_byte`


------
https://chatgpt.com/codex/tasks/task_e_689a829b9644832a8f6cdb6e26f9e555